### PR TITLE
Workaround Parametrized Host

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2924,7 +2924,7 @@ packages:
     dev: false
 
   /array-flatten/1.1.1:
-    resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
     dev: false
 
   /array-includes/3.1.5:
@@ -3171,7 +3171,7 @@ packages:
     dev: false
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
     dev: false
 
   /buffer-from/1.1.2:
@@ -3328,7 +3328,7 @@ packages:
     dev: false
 
   /charenc/0.0.2:
-    resolution: {integrity: sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=}
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
     dev: false
 
   /check-error/1.0.2:
@@ -3471,7 +3471,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
   /concurrently/6.5.1:
@@ -3532,7 +3532,7 @@ packages:
     dev: false
 
   /cookie-signature/1.0.6:
-    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
     dev: false
 
   /cookie/0.4.2:
@@ -3634,7 +3634,7 @@ packages:
     dev: false
 
   /crypt/0.0.2:
-    resolution: {integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=}
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
     dev: false
 
   /csv-parse/4.16.3:
@@ -3892,7 +3892,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 4.9.0-dev.20221019
+      typescript: 4.9.0-dev.20221024
     dev: false
 
   /downlevel-dts/0.8.0:
@@ -3911,11 +3911,11 @@ packages:
     dev: false
 
   /edge-launcher/1.2.2:
-    resolution: {integrity: sha1-60Cq+9Bnpup27/+rBke81VCbN7I=}
+    resolution: {integrity: sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==}
     dev: false
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
   /electron-to-chromium/1.4.284:
@@ -4799,7 +4799,7 @@ packages:
     dev: false
 
   /fresh/0.5.2:
-    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -4939,7 +4939,7 @@ packages:
     dev: false
 
   /github-from-package/0.0.0:
-    resolution: {integrity: sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=}
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
     dev: false
 
   /glob-parent/5.1.2:
@@ -6336,7 +6336,7 @@ packages:
     dev: false
 
   /media-typer/0.3.0:
-    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -6346,7 +6346,7 @@ packages:
     dev: false
 
   /merge-descriptors/1.0.1:
-    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
     dev: false
 
   /merge-source-map/1.1.0:
@@ -6759,7 +6759,7 @@ packages:
     dev: false
 
   /noms/0.0.0:
-    resolution: {integrity: sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=}
+    resolution: {integrity: sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==}
     dependencies:
       inherits: 2.0.4
       readable-stream: 1.0.34
@@ -8838,8 +8838,8 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript/4.9.0-dev.20221019:
-    resolution: {integrity: sha512-FgRBDKHZQAbayBvRcfFpjtmztLCobGom2k5W5nFqCXDb/XKYn0oG/8s6O9le3lGIt3+1FC7FYMmqvR5qRW50AA==}
+  /typescript/4.9.0-dev.20221024:
+    resolution: {integrity: sha512-emPfkqIHzCqpQeKpZ7FF7SwFvGcG2B6+sWGIW1xthggJbJGdqgBWAok5XTIoyS4G1GITQTOcXJLHpI/czVoinQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
@@ -8963,7 +8963,7 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: false
 
@@ -9532,7 +9532,7 @@ packages:
     dev: false
 
   file:projects/ai-anomaly-detector.tgz:
-    resolution: {integrity: sha512-2dMYvO6HT5uWfal6sZWWe/ZOn8u+Uc1FidAdyI9DBoIf1K7edy9PXrlPMDpyAoXx8sU0srBr1mzQhT7KjQvEvg==, tarball: file:projects/ai-anomaly-detector.tgz}
+    resolution: {integrity: sha512-+mr3yEj6NbyzRvFAXj7TSP8YPAcusW8BJ3s2b4aOgzZa6IDdOVA0C0nP2ZDzyOFK7fGFP/owU8n0lNGL7+hXZw==, tarball: file:projects/ai-anomaly-detector.tgz}
     name: '@rush-temp/ai-anomaly-detector'
     version: 0.0.0
     dependencies:
@@ -9540,6 +9540,7 @@ packages:
       '@azure/identity': 2.1.0
       '@microsoft/api-extractor': 7.33.4
       '@types/chai': 4.3.3
+      '@types/mocha': 7.0.2
       '@types/node': 14.18.32
       autorest: 3.6.2
       chai: 4.3.6
@@ -18263,7 +18264,7 @@ packages:
       '@azure/monitor-ingestion': 1.0.0-beta.2
       '@types/node': 12.20.24
       dotenv: 8.6.0
-      eslint: 8.24.0
+      eslint: 8.25.0
       prettier: 2.7.1
       rimraf: 3.0.2
       ts-node: 10.9.1_c4df58cde868390b07e351f745ee8a9e

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/package.json
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/package.json
@@ -4,13 +4,22 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.1",
   "description": "A generated SDK for AnomalyDetectorRest.",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/ai-anomaly-detector.d.ts",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/src/",
@@ -19,7 +28,9 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=14.0.0" },
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -97,7 +108,10 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/anomalydetector/ai-anomaly-detector-rest/README.md",
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
   "browser": {
@@ -105,7 +119,9 @@
   },
   "//sampleConfiguration": {
     "productName": "AnomalyDetectorRest",
-    "productSlugs": ["azure"],
+    "productSlugs": [
+      "azure"
+    ],
     "disableDocsMs": true,
     "apiRefLink": "https://docs.microsoft.com/javascript/api/@azure-rest/ai-anomaly-detector?view=azure-node-preview"
   }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_multivariate_detection.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/samples-dev/sample_multivariate_detection.ts
@@ -12,6 +12,7 @@ import AnomalyDetector, {
   CreateAndTrainMultivariateModelParameters,
   ListMultivariateModelsParameters,
   paginate,
+  isUnexpected,
 } from "@azure-rest/ai-anomaly-detector";
 import { AzureKeyCredential } from "@azure/core-auth";
 
@@ -22,7 +23,6 @@ dotenv.config();
 // You will need to set this environment variables or edit the following values
 const apiKey = process.env["ANOMALY_DETECTOR_API_KEY"] || "";
 const endpoint = process.env["ANOMALY_DETECTOR_ENDPOINT"] || "";
-const apiVersion = "v1.1";
 
 // const dataSource = "<your data source>";
 const dataSource =
@@ -41,7 +41,7 @@ export async function main() {
   const options: ListMultivariateModelsParameters = {
     queryParameters: { skip: 0, top: 10 },
   };
-  const initialResponse = await client.path(`/{ApiVersion}/multivariate/models`).get(options);
+  const initialResponse = await client.path(`/multivariate/models`).get(options);
   const pageData = paginate(client, initialResponse);
   const listModelsResult = [];
   for await (const item of pageData) {
@@ -69,47 +69,39 @@ export async function main() {
 
   // train model
   const createModelResult = await client
-    .path("/{ApiVersion}/multivariate/models")
-    .post(createMultivariateModelParameters)
-    .then((res) => {
-      if (!("modelId" in res.body)) {
-        throw res.body;
-      }
-      return res.body;
-    });
+    .path("/multivariate/models")
+    .post(createMultivariateModelParameters);
+
+  if (isUnexpected(createModelResult)) {
+    throw createModelResult.body;
+  }
+
   console.log(createModelResult);
 
   // get model status
-  const modelId = createModelResult.modelId;
-  let modelResponse = await client
-    .path("/{ApiVersion}/multivariate/models/{modelId}", modelId)
-    .get()
-    .then((res) => {
-      if (!("modelInfo" in res.body)) {
-        throw res.body;
-      }
-      return res.body;
-    });
+  const modelId = createModelResult.body.modelId;
+  let modelResponse = await client.path("/multivariate/models/{modelId}", modelId).get();
+  if (isUnexpected(modelResponse)) {
+    throw modelResponse.body;
+  }
+
   console.log(modelResponse);
-  let modelStatus = modelResponse.modelInfo && modelResponse.modelInfo.status;
+  let modelStatus = modelResponse.body.modelInfo?.status;
 
   while (modelStatus != "READY" && modelStatus != "FAILED") {
     await sleep(2000).then(() => {});
-    modelResponse = await client
-      .path("/{ApiVersion}/multivariate/models/{modelId}", modelId)
-      .get()
-      .then((res) => {
-        if (!("modelInfo" in res.body)) {
-          throw res.body;
-        }
-        return res.body;
-      });
-    modelStatus = modelResponse.modelInfo && modelResponse.modelInfo.status;
+    modelResponse = await client.path("/multivariate/models/{modelId}", modelId).get();
+
+    if (isUnexpected(modelResponse)) {
+      throw modelResponse.body;
+    }
+
+    modelStatus = modelResponse.body.modelInfo?.status;
   }
 
   if (modelStatus == "FAILED") {
     console.log("Training failed.\nErrors:");
-    for (const error of (modelResponse.modelInfo && modelResponse.modelInfo.errors) || []) {
+    for (const error of modelResponse.body.modelInfo?.errors || []) {
       console.log("Error code: " + error.code + ". Message: " + error.message);
     }
     return;
@@ -129,45 +121,40 @@ export async function main() {
     headers: { "Content-Type": "application/json" },
   };
   const batchDetectionResponse = await client
-    .path("/{ApiVersion}/multivariate/models/{modelId}:detect-batch", modelId)
-    .post(batchDetectAnomalyParameters)
-    .then((res) => {
-      if (!("resultId" in res.body)) {
-        throw res.body;
-      }
-      return res.body;
-    });
+    .path("/multivariate/models/{modelId}:detect-batch", modelId)
+    .post(batchDetectAnomalyParameters);
 
-  const resultId = batchDetectionResponse.resultId;
+  if (isUnexpected(batchDetectionResponse)) {
+    throw batchDetectionResponse.body;
+  }
+
+  const resultId = batchDetectionResponse.body.resultId;
   let getDetectionResultResponse = await client
-    .path("/{ApiVersion}/multivariate/detect-batch/{resultId}", resultId)
-    .get()
-    .then((res) => {
-      if (!("summary" in res.body)) {
-        throw res.body;
-      }
-      return res.body;
-    });
-  let resultStatus = getDetectionResultResponse.summary.status;
+    .path("/multivariate/detect-batch/{resultId}", resultId)
+    .get();
+
+  if (isUnexpected(getDetectionResultResponse)) {
+    throw getDetectionResultResponse.body;
+  }
+
+  let resultStatus = getDetectionResultResponse.body.summary.status;
 
   while (resultStatus != "READY" && resultStatus != "FAILED") {
     await sleep(1000).then(() => {});
     getDetectionResultResponse = await client
-      .path("/{ApiVersion}/multivariate/detect-batch/{resultId}", resultId)
-      .get()
-      .then((res) => {
-        if (!("summary" in res.body)) {
-          throw res.body;
-        }
-        return res.body;
-      });
-    resultStatus = getDetectionResultResponse.summary.status;
+      .path("/multivariate/detect-batch/{resultId}", resultId)
+      .get();
+
+    if (isUnexpected(getDetectionResultResponse)) {
+      throw getDetectionResultResponse.body;
+    }
+    resultStatus = getDetectionResultResponse.body.summary.status;
   }
 
   if (resultStatus == "FAILED") {
     console.log("Detection failed.");
     console.log("Errors:");
-    for (let error of getDetectionResultResponse.summary.errors || []) {
+    for (let error of getDetectionResultResponse.body.summary.errors || []) {
       console.log("Error code: " + error.code + ". Message: " + error.message);
     }
     return;
@@ -175,12 +162,10 @@ export async function main() {
 
   // if result status is "READY"
   console.log("Result status: " + resultStatus);
-  console.log("Result Id: " + getDetectionResultResponse.resultId);
+  console.log("Result Id: " + getDetectionResultResponse.body.resultId);
 
   // delete model
-  const deleteResult = await client
-    .path("/{ApiVersion}/multivariate/models/{modelId}", modelId)
-    .delete();
+  const deleteResult = await client.path("/multivariate/models/{modelId}", modelId).delete();
 
   if (deleteResult.status == "204") {
     console.log("New model has been deleted.");

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/anomalyDetectorRest.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/anomalyDetectorRest.ts
@@ -13,15 +13,16 @@ import { AnomalyDetectorRestClient } from "./clientDefinitions";
 export default function createClient(
   Endpoint: string,
   credentials: KeyCredential,
-  options: ClientOptions = {}
+  options: ClientOptions & { apiVersion?: string } = {}
 ): AnomalyDetectorRestClient {
-  const baseUrl = options.baseUrl ?? `${Endpoint}/anomalydetector`;
+  const apiVersion = options.apiVersion ?? "v1.1";
+  const baseUrl = options.baseUrl ?? `${Endpoint}/anomalydetector/${apiVersion}`;
 
   options = {
     ...options,
     credentials: {
-      apiKeyHeaderName: "Ocp-Apim-Subscription-Key"
-    }
+      apiKeyHeaderName: "Ocp-Apim-Subscription-Key",
+    },
   };
 
   const userAgentInfo = `azsdk-js-ai-anomaly-detector-rest/1.0.0-beta.1`;
@@ -32,15 +33,11 @@ export default function createClient(
   options = {
     ...options,
     userAgentOptions: {
-      userAgentPrefix
-    }
+      userAgentPrefix,
+    },
   };
 
-  const client = getClient(
-    baseUrl,
-    credentials,
-    options
-  ) as AnomalyDetectorRestClient;
+  const client = getClient(baseUrl, credentials, options) as AnomalyDetectorRestClient;
 
   return client;
 }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/clientDefinitions.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/clientDefinitions.ts
@@ -11,7 +11,7 @@ import {
   DeleteMultivariateModelParameters,
   GetMultivariateModelParameters,
   DetectMultivariateBatchAnomalyParameters,
-  DetectMultivariateLastAnomalyParameters
+  DetectMultivariateLastAnomalyParameters,
 } from "./parameters";
 import {
   DetectUnivariateEntireSeries200Response,
@@ -33,7 +33,7 @@ import {
   DetectMultivariateBatchAnomaly202Response,
   DetectMultivariateBatchAnomalyDefaultResponse,
   DetectMultivariateLastAnomaly200Response,
-  DetectMultivariateLastAnomalyDefaultResponse
+  DetectMultivariateLastAnomalyDefaultResponse,
 } from "./responses";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
@@ -42,8 +42,7 @@ export interface DetectUnivariateEntireSeries {
   post(
     options: DetectUnivariateEntireSeriesParameters
   ): StreamableMethod<
-    | DetectUnivariateEntireSeries200Response
-    | DetectUnivariateEntireSeriesDefaultResponse
+    DetectUnivariateEntireSeries200Response | DetectUnivariateEntireSeriesDefaultResponse
   >;
 }
 
@@ -52,8 +51,7 @@ export interface DetectUnivariateLastPoint {
   post(
     options: DetectUnivariateLastPointParameters
   ): StreamableMethod<
-    | DetectUnivariateLastPoint200Response
-    | DetectUnivariateLastPointDefaultResponse
+    DetectUnivariateLastPoint200Response | DetectUnivariateLastPointDefaultResponse
   >;
 }
 
@@ -62,8 +60,7 @@ export interface DetectUnivariateChangePoint {
   post(
     options: DetectUnivariateChangePointParameters
   ): StreamableMethod<
-    | DetectUnivariateChangePoint200Response
-    | DetectUnivariateChangePointDefaultResponse
+    DetectUnivariateChangePoint200Response | DetectUnivariateChangePointDefaultResponse
   >;
 }
 
@@ -82,30 +79,23 @@ export interface CreateAndTrainMultivariateModel {
   post(
     options: CreateAndTrainMultivariateModelParameters
   ): StreamableMethod<
-    | CreateAndTrainMultivariateModel201Response
-    | CreateAndTrainMultivariateModelDefaultResponse
+    CreateAndTrainMultivariateModel201Response | CreateAndTrainMultivariateModelDefaultResponse
   >;
   /** List models of a resource. */
   get(
     options?: ListMultivariateModelsParameters
-  ): StreamableMethod<
-    ListMultivariateModels200Response | ListMultivariateModelsDefaultResponse
-  >;
+  ): StreamableMethod<ListMultivariateModels200Response | ListMultivariateModelsDefaultResponse>;
 }
 
 export interface DeleteMultivariateModel {
   /** Delete an existing multivariate model according to the modelId */
   delete(
     options?: DeleteMultivariateModelParameters
-  ): StreamableMethod<
-    DeleteMultivariateModel204Response | DeleteMultivariateModelDefaultResponse
-  >;
+  ): StreamableMethod<DeleteMultivariateModel204Response | DeleteMultivariateModelDefaultResponse>;
   /** Get detailed information of multivariate model, including the training status and variables used in the model. */
   get(
     options?: GetMultivariateModelParameters
-  ): StreamableMethod<
-    GetMultivariateModel200Response | GetMultivariateModelDefaultResponse
-  >;
+  ): StreamableMethod<GetMultivariateModel200Response | GetMultivariateModelDefaultResponse>;
 }
 
 export interface DetectMultivariateBatchAnomaly {
@@ -113,8 +103,7 @@ export interface DetectMultivariateBatchAnomaly {
   post(
     options: DetectMultivariateBatchAnomalyParameters
   ): StreamableMethod<
-    | DetectMultivariateBatchAnomaly202Response
-    | DetectMultivariateBatchAnomalyDefaultResponse
+    DetectMultivariateBatchAnomaly202Response | DetectMultivariateBatchAnomalyDefaultResponse
   >;
 }
 
@@ -123,42 +112,34 @@ export interface DetectMultivariateLastAnomaly {
   post(
     options: DetectMultivariateLastAnomalyParameters
   ): StreamableMethod<
-    | DetectMultivariateLastAnomaly200Response
-    | DetectMultivariateLastAnomalyDefaultResponse
+    DetectMultivariateLastAnomaly200Response | DetectMultivariateLastAnomalyDefaultResponse
   >;
 }
 
 export interface Routes {
-  /** Resource for '/\{ApiVersion\}/timeseries/entire/detect' has methods for the following verbs: post */
+  /** Resource for '/timeseries/entire/detect' has methods for the following verbs: post */
+  (path: "/timeseries/entire/detect"): DetectUnivariateEntireSeries;
+  /** Resource for '/timeseries/last/detect' has methods for the following verbs: post */
+  (path: "/timeseries/last/detect"): DetectUnivariateLastPoint;
+  /** Resource for '/timeseries/changepoint/detect' has methods for the following verbs: post */
+  (path: "/timeseries/changepoint/detect"): DetectUnivariateChangePoint;
+  /** Resource for '/multivariate/detect-batch/\{resultId\}' has methods for the following verbs: get */
   (
-    path: "/{ApiVersion}/timeseries/entire/detect"
-  ): DetectUnivariateEntireSeries;
-  /** Resource for '/\{ApiVersion\}/timeseries/last/detect' has methods for the following verbs: post */
-  (path: "/{ApiVersion}/timeseries/last/detect"): DetectUnivariateLastPoint;
-  /** Resource for '/\{ApiVersion\}/timeseries/changepoint/detect' has methods for the following verbs: post */
-  (
-    path: "/{ApiVersion}/timeseries/changepoint/detect"
-  ): DetectUnivariateChangePoint;
-  /** Resource for '/\{ApiVersion\}/multivariate/detect-batch/\{resultId\}' has methods for the following verbs: get */
-  (
-    path: "/{ApiVersion}/multivariate/detect-batch/{resultId}",
+    path: "/multivariate/detect-batch/{resultId}",
     resultId: string
   ): GetMultivariateBatchDetectionResult;
-  /** Resource for '/\{ApiVersion\}/multivariate/models' has methods for the following verbs: post, get */
-  (path: "/{ApiVersion}/multivariate/models"): CreateAndTrainMultivariateModel;
-  /** Resource for '/\{ApiVersion\}/multivariate/models/\{modelId\}' has methods for the following verbs: delete, get */
+  /** Resource for '/multivariate/models' has methods for the following verbs: post, get */
+  (path: "/multivariate/models"): CreateAndTrainMultivariateModel;
+  /** Resource for '/multivariate/models/\{modelId\}' has methods for the following verbs: delete, get */
+  (path: "/multivariate/models/{modelId}", modelId: string): DeleteMultivariateModel;
+  /** Resource for '/multivariate/models/\{modelId\}:detect-batch' has methods for the following verbs: post */
   (
-    path: "/{ApiVersion}/multivariate/models/{modelId}",
-    modelId: string
-  ): DeleteMultivariateModel;
-  /** Resource for '/\{ApiVersion\}/multivariate/models/\{modelId\}:detect-batch' has methods for the following verbs: post */
-  (
-    path: "/{ApiVersion}/multivariate/models/{modelId}:detect-batch",
+    path: "/multivariate/models/{modelId}:detect-batch",
     modelId: string
   ): DetectMultivariateBatchAnomaly;
-  /** Resource for '/\{ApiVersion\}/multivariate/models/\{modelId\}:detect-last' has methods for the following verbs: post */
+  /** Resource for '/multivariate/models/\{modelId\}:detect-last' has methods for the following verbs: post */
   (
-    path: "/{ApiVersion}/multivariate/models/{modelId}:detect-last",
+    path: "/multivariate/models/{modelId}:detect-last",
     modelId: string
   ): DetectMultivariateLastAnomaly;
 }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/isUnexpected.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/isUnexpected.ts
@@ -21,37 +21,31 @@ import {
   DetectMultivariateBatchAnomaly202Response,
   DetectMultivariateBatchAnomalyDefaultResponse,
   DetectMultivariateLastAnomaly200Response,
-  DetectMultivariateLastAnomalyDefaultResponse
+  DetectMultivariateLastAnomalyDefaultResponse,
 } from "./responses";
 
 const responseMap: Record<string, string[]> = {
-  "POST /{ApiVersion}/timeseries/entire/detect": ["200"],
-  "POST /{ApiVersion}/timeseries/last/detect": ["200"],
-  "POST /{ApiVersion}/timeseries/changepoint/detect": ["200"],
-  "GET /{ApiVersion}/multivariate/detect-batch/{resultId}": ["200"],
-  "POST /{ApiVersion}/multivariate/models": ["201"],
-  "GET /{ApiVersion}/multivariate/models": ["200"],
-  "DELETE /{ApiVersion}/multivariate/models/{modelId}": ["204"],
-  "GET /{ApiVersion}/multivariate/models/{modelId}": ["200"],
-  "POST /{ApiVersion}/multivariate/models/{modelId}:detect-batch": ["202"],
-  "GET /{ApiVersion}/multivariate/models/{modelId}:detect-batch": ["202"],
-  "POST /{ApiVersion}/multivariate/models/{modelId}:detect-last": ["200"]
+  "POST /timeseries/entire/detect": ["200"],
+  "POST /timeseries/last/detect": ["200"],
+  "POST /timeseries/changepoint/detect": ["200"],
+  "GET /multivariate/detect-batch/{resultId}": ["200"],
+  "POST /multivariate/models": ["201"],
+  "GET /multivariate/models": ["200"],
+  "DELETE /multivariate/models/{modelId}": ["204"],
+  "GET /multivariate/models/{modelId}": ["200"],
+  "POST /multivariate/models/{modelId}:detect-batch": ["202"],
+  "GET /multivariate/models/{modelId}:detect-batch": ["202"],
+  "POST /multivariate/models/{modelId}:detect-last": ["200"],
 };
 
 export function isUnexpected(
-  response:
-    | DetectUnivariateEntireSeries200Response
-    | DetectUnivariateEntireSeriesDefaultResponse
+  response: DetectUnivariateEntireSeries200Response | DetectUnivariateEntireSeriesDefaultResponse
 ): response is DetectUnivariateEntireSeriesDefaultResponse;
 export function isUnexpected(
-  response:
-    | DetectUnivariateLastPoint200Response
-    | DetectUnivariateLastPointDefaultResponse
+  response: DetectUnivariateLastPoint200Response | DetectUnivariateLastPointDefaultResponse
 ): response is DetectUnivariateLastPointDefaultResponse;
 export function isUnexpected(
-  response:
-    | DetectUnivariateChangePoint200Response
-    | DetectUnivariateChangePointDefaultResponse
+  response: DetectUnivariateChangePoint200Response | DetectUnivariateChangePointDefaultResponse
 ): response is DetectUnivariateChangePointDefaultResponse;
 export function isUnexpected(
   response:
@@ -64,19 +58,13 @@ export function isUnexpected(
     | CreateAndTrainMultivariateModelDefaultResponse
 ): response is CreateAndTrainMultivariateModelDefaultResponse;
 export function isUnexpected(
-  response:
-    | ListMultivariateModels200Response
-    | ListMultivariateModelsDefaultResponse
+  response: ListMultivariateModels200Response | ListMultivariateModelsDefaultResponse
 ): response is ListMultivariateModelsDefaultResponse;
 export function isUnexpected(
-  response:
-    | DeleteMultivariateModel204Response
-    | DeleteMultivariateModelDefaultResponse
+  response: DeleteMultivariateModel204Response | DeleteMultivariateModelDefaultResponse
 ): response is DeleteMultivariateModelDefaultResponse;
 export function isUnexpected(
-  response:
-    | GetMultivariateModel200Response
-    | GetMultivariateModelDefaultResponse
+  response: GetMultivariateModel200Response | GetMultivariateModelDefaultResponse
 ): response is GetMultivariateModelDefaultResponse;
 export function isUnexpected(
   response:
@@ -84,9 +72,7 @@ export function isUnexpected(
     | DetectMultivariateBatchAnomalyDefaultResponse
 ): response is DetectMultivariateBatchAnomalyDefaultResponse;
 export function isUnexpected(
-  response:
-    | DetectMultivariateLastAnomaly200Response
-    | DetectMultivariateLastAnomalyDefaultResponse
+  response: DetectMultivariateLastAnomaly200Response | DetectMultivariateLastAnomalyDefaultResponse
 ): response is DetectMultivariateLastAnomalyDefaultResponse;
 export function isUnexpected(
   response:
@@ -144,50 +130,34 @@ function geParametrizedPathSuccess(method: string, path: string): string[] {
     const candidatePath = getPathFromMapKey(key);
     // Get each part of the url path
     const candidateParts = candidatePath.split("/");
-
-    // If the candidate and actual paths don't match in size
-    // we move on to the next candidate path
-    if (
-      candidateParts.length === pathParts.length &&
-      hasParametrizedPath(key)
-    ) {
-      // track if we have found a match to return the values found.
-      let found = true;
-      for (let i = 0; i < candidateParts.length; i++) {
-        if (
-          candidateParts[i]?.startsWith("{") &&
-          candidateParts[i]?.endsWith("}")
-        ) {
-          // If the current part of the candidate is a "template" part
-          // it is a match with the actual path part on hand
-          // skip as the parameterized part can match anything
-          continue;
-        }
-
-        // If the candidate part is not a template and
-        // the parts don't match mark the candidate as not found
-        // to move on with the next candidate path.
-        if (candidateParts[i] !== pathParts[i]) {
-          found = false;
-          break;
-        }
+    // track if we have found a match to return the values found.
+    let found = true;
+    for (let i = candidateParts.length - 1; i >= 0; i--) {
+      if (candidateParts[i]?.startsWith("{") && candidateParts[i]?.endsWith("}")) {
+        // If the current part of the candidate is a "template" part
+        // it is a match with the actual path part on hand
+        // skip as the parameterized part can match anything
+        continue;
       }
 
-      // We finished evaluating the current candidate parts
-      // if all parts matched we return the success values form
-      // the path mapping.
-      if (found) {
-        return value;
+      // If the candidate part is not a template and
+      // the parts don't match mark the candidate as not found
+      // to move on with the next candidate path.
+      if (candidateParts[i] !== pathParts[i]) {
+        found = false;
+        break;
       }
     }
-  }
 
+    // We finished evaluating the current candidate parts
+    // if all parts matched we return the success values form
+    // the path mapping.
+    if (found) {
+      return value;
+    }
+  }
   // No match was found, return an empty array.
   return [];
-}
-
-function hasParametrizedPath(path: string): boolean {
-  return path.includes("/{");
 }
 
 function getPathFromMapKey(mapKey: string): string {

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/outputModels.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/outputModels.ts
@@ -148,8 +148,7 @@ export interface AnomalyValueOutput {
 }
 
 /** Interpretation contains more details of the anomaly, which will help with root cause analysis. */
-export interface AnomalyValueInterpretationItemOutput
-  extends AnomalyInterpretationOutput {}
+export interface AnomalyValueInterpretationItemOutput extends AnomalyInterpretationOutput {}
 
 export interface AnomalyInterpretationOutput {
   /** Variable. */

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/paginateHelper.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/paginateHelper.ts
@@ -1,16 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  getPagedAsyncIterator,
-  PagedAsyncIterableIterator,
-  PagedResult
-} from "@azure/core-paging";
-import {
-  Client,
-  createRestError,
-  PathUncheckedResponse
-} from "@azure-rest/core-client";
+import { getPagedAsyncIterator, PagedAsyncIterableIterator, PagedResult } from "@azure/core-paging";
+import { Client, createRestError, PathUncheckedResponse } from "@azure-rest/core-client";
 
 /**
  * Helper type to extract the type of an array
@@ -81,18 +73,16 @@ export function paginate<TResponse extends PathUncheckedResponse>(
       typeof customGetPage === "function"
         ? customGetPage
         : async (pageLink: string) => {
-            const result = firstRun
-              ? initialResponse
-              : await client.pathUnchecked(pageLink).get();
+            const result = firstRun ? initialResponse : await client.pathUnchecked(pageLink).get();
             firstRun = false;
             checkPagingRequest(result);
             const nextLink = getNextLink(result.body, nextLinkName);
             const values = getElements<TElement>(result.body, itemName);
             return {
               page: values,
-              nextPageLink: nextLink
+              nextPageLink: nextLink,
             };
-          }
+          },
   };
 
   return getPagedAsyncIterator(pagedResult);
@@ -109,9 +99,7 @@ function getNextLink(body: unknown, nextLinkName?: string): string | undefined {
   const nextLink = (body as Record<string, unknown>)[nextLinkName];
 
   if (typeof nextLink !== "string" && typeof nextLink !== "undefined") {
-    throw new Error(
-      `Body Property ${nextLinkName} should be a string or undefined`
-    );
+    throw new Error(`Body Property ${nextLinkName} should be a string or undefined`);
   }
 
   return nextLink;
@@ -139,18 +127,7 @@ function getElements<T = unknown>(body: unknown, itemName: string): T[] {
  * Checks if a request failed
  */
 function checkPagingRequest(response: PathUncheckedResponse): void {
-  const Http2xxStatusCodes = [
-    "200",
-    "201",
-    "202",
-    "203",
-    "204",
-    "205",
-    "206",
-    "207",
-    "208",
-    "226"
-  ];
+  const Http2xxStatusCodes = ["200", "201", "202", "203", "204", "205", "206", "207", "208", "226"];
   if (!Http2xxStatusCodes.includes(response.status)) {
     throw createRestError(
       `Pagination failed with unexpected statusCode ${response.status}`,
@@ -173,9 +150,7 @@ function getPaginationProperties(initialResponse: PathUncheckedResponse) {
   let itemName: string | undefined;
 
   for (const name of nextLinkNames) {
-    const nextLink = (initialResponse.body as Record<string, unknown>)[
-      name
-    ] as string;
+    const nextLink = (initialResponse.body as Record<string, unknown>)[name] as string;
     if (nextLink) {
       nextLinkName = name;
       break;
@@ -183,9 +158,7 @@ function getPaginationProperties(initialResponse: PathUncheckedResponse) {
   }
 
   for (const name of itemNames) {
-    const item = (initialResponse.body as Record<string, unknown>)[
-      name
-    ] as string;
+    const item = (initialResponse.body as Record<string, unknown>)[name] as string;
     if (item) {
       itemName = name;
       break;
@@ -195,7 +168,7 @@ function getPaginationProperties(initialResponse: PathUncheckedResponse) {
   if (!itemName) {
     throw new Error(
       `Couldn't paginate response\n Body doesn't contain an array property with name: ${[
-        ...itemNames
+        ...itemNames,
       ].join(" OR ")}`
     );
   }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/parameters.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/parameters.ts
@@ -7,7 +7,7 @@ import {
   ChangePointDetectRequest,
   ModelInfo,
   DetectionRequest,
-  LastDetectionRequest
+  LastDetectionRequest,
 } from "./models";
 
 export interface DetectUnivariateEntireSeriesBodyParam {
@@ -78,8 +78,7 @@ export interface ListMultivariateModelsQueryParam {
   queryParameters?: ListMultivariateModelsQueryParamProperties;
 }
 
-export type ListMultivariateModelsParameters = ListMultivariateModelsQueryParam &
-  RequestParameters;
+export type ListMultivariateModelsParameters = ListMultivariateModelsQueryParam & RequestParameters;
 export type DeleteMultivariateModelParameters = RequestParameters;
 export type GetMultivariateModelParameters = RequestParameters;
 

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/pollingHelper.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/pollingHelper.ts
@@ -8,7 +8,7 @@ import {
   LroEngineOptions,
   LroResponse,
   PollerLike,
-  PollOperationState
+  PollOperationState,
 } from "@azure/core-lro";
 
 /**
@@ -37,14 +37,11 @@ export function getLongRunningPoller<TResult extends HttpResponse>(
       // to get the latest status. We use the client provided and the polling path
       // which is an opaque URL provided by caller, the service sends this in one of the following headers: operation-location, azure-asyncoperation or location
       // depending on the lro pattern that the service implements. If non is provided we default to the initial path.
-      const response = await client
-        .pathUnchecked(path ?? initialResponse.request.url)
-        .get();
+      const response = await client.pathUnchecked(path ?? initialResponse.request.url).get();
       const lroResponse = getLroResponse(response as TResult);
-      lroResponse.rawResponse.headers["x-ms-original-url"] =
-        initialResponse.request.url;
+      lroResponse.rawResponse.headers["x-ms-original-url"] = initialResponse.request.url;
       return lroResponse;
-    }
+    },
   };
 
   return new LroEngine(poller, options);
@@ -55,13 +52,9 @@ export function getLongRunningPoller<TResult extends HttpResponse>(
  * @param response - a rest client http response
  * @returns - An LRO response that the LRO engine can work with
  */
-function getLroResponse<TResult extends HttpResponse>(
-  response: TResult
-): LroResponse<TResult> {
+function getLroResponse<TResult extends HttpResponse>(response: TResult): LroResponse<TResult> {
   if (Number.isNaN(response.status)) {
-    throw new TypeError(
-      `Status code of the response is not a number. Value: ${response.status}`
-    );
+    throw new TypeError(`Status code of the response is not a number. Value: ${response.status}`);
   }
 
   return {
@@ -69,7 +62,7 @@ function getLroResponse<TResult extends HttpResponse>(
     rawResponse: {
       ...response,
       statusCode: Number.parseInt(response.status),
-      body: response.body
-    }
+      body: response.body,
+    },
   };
 }

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/src/responses.ts
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/src/responses.ts
@@ -12,7 +12,7 @@ import {
   ErrorResponseOutput,
   ModelOutput,
   ModelListOutput,
-  LastDetectionResultOutput
+  LastDetectionResultOutput,
 } from "./outputModels";
 
 /** This operation generates a model with an entire series, each point is detected with the same model. With this method, points before and after a certain point are used to determine whether it is an anomaly. The entire detection can give user an overall status of the time series. */
@@ -27,8 +27,7 @@ export interface DetectUnivariateEntireSeriesDefaultHeaders {
 }
 
 /** This operation generates a model with an entire series, each point is detected with the same model. With this method, points before and after a certain point are used to determine whether it is an anomaly. The entire detection can give user an overall status of the time series. */
-export interface DetectUnivariateEntireSeriesDefaultResponse
-  extends HttpResponse {
+export interface DetectUnivariateEntireSeriesDefaultResponse extends HttpResponse {
   status: string;
   body: AnomalyDetectorErrorOutput;
   headers: RawHttpHeaders & DetectUnivariateEntireSeriesDefaultHeaders;
@@ -64,16 +63,14 @@ export interface DetectUnivariateChangePointDefaultHeaders {
 }
 
 /** Evaluate change point score of every series point */
-export interface DetectUnivariateChangePointDefaultResponse
-  extends HttpResponse {
+export interface DetectUnivariateChangePointDefaultResponse extends HttpResponse {
   status: string;
   body: AnomalyDetectorErrorOutput;
   headers: RawHttpHeaders & DetectUnivariateChangePointDefaultHeaders;
 }
 
 /** For asynchronous inference, get multivariate anomaly detection result based on resultId returned by the BatchDetectAnomaly api. */
-export interface GetMultivariateBatchDetectionResult200Response
-  extends HttpResponse {
+export interface GetMultivariateBatchDetectionResult200Response extends HttpResponse {
   status: "200";
   body: DetectionResultOutput;
 }
@@ -84,8 +81,7 @@ export interface GetMultivariateBatchDetectionResultDefaultHeaders {
 }
 
 /** For asynchronous inference, get multivariate anomaly detection result based on resultId returned by the BatchDetectAnomaly api. */
-export interface GetMultivariateBatchDetectionResultDefaultResponse
-  extends HttpResponse {
+export interface GetMultivariateBatchDetectionResultDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponseOutput;
   headers: RawHttpHeaders & GetMultivariateBatchDetectionResultDefaultHeaders;
@@ -97,8 +93,7 @@ export interface CreateAndTrainMultivariateModel201Headers {
 }
 
 /** Create and train a multivariate anomaly detection model. The request must include a source parameter to indicate an externally accessible Azure blob storage URI.There are two types of data input: An URI pointed to an Azure blob storage folder which contains multiple CSV files, and each CSV file contains two columns, timestamp and variable. Another type of input is an URI pointed to a CSV file in Azure blob storage, which contains all the variables and a timestamp column. */
-export interface CreateAndTrainMultivariateModel201Response
-  extends HttpResponse {
+export interface CreateAndTrainMultivariateModel201Response extends HttpResponse {
   status: "201";
   body: ModelOutput;
   headers: RawHttpHeaders & CreateAndTrainMultivariateModel201Headers;
@@ -110,8 +105,7 @@ export interface CreateAndTrainMultivariateModelDefaultHeaders {
 }
 
 /** Create and train a multivariate anomaly detection model. The request must include a source parameter to indicate an externally accessible Azure blob storage URI.There are two types of data input: An URI pointed to an Azure blob storage folder which contains multiple CSV files, and each CSV file contains two columns, timestamp and variable. Another type of input is an URI pointed to a CSV file in Azure blob storage, which contains all the variables and a timestamp column. */
-export interface CreateAndTrainMultivariateModelDefaultResponse
-  extends HttpResponse {
+export interface CreateAndTrainMultivariateModelDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponseOutput;
   headers: RawHttpHeaders & CreateAndTrainMultivariateModelDefaultHeaders;
@@ -179,8 +173,7 @@ export interface DetectMultivariateBatchAnomaly202Headers {
 }
 
 /** Submit multivariate anomaly detection task with the modelId of trained model and inference data, the input schema should be the same with the training request. The request will complete asynchronously and return a resultId to query the detection result.The request should be a source link to indicate an externally accessible Azure storage Uri, either pointed to an Azure blob storage folder, or pointed to a CSV file in Azure blob storage. */
-export interface DetectMultivariateBatchAnomaly202Response
-  extends HttpResponse {
+export interface DetectMultivariateBatchAnomaly202Response extends HttpResponse {
   status: "202";
   body: DetectionResultOutput;
   headers: RawHttpHeaders & DetectMultivariateBatchAnomaly202Headers;
@@ -192,8 +185,7 @@ export interface DetectMultivariateBatchAnomalyDefaultHeaders {
 }
 
 /** Submit multivariate anomaly detection task with the modelId of trained model and inference data, the input schema should be the same with the training request. The request will complete asynchronously and return a resultId to query the detection result.The request should be a source link to indicate an externally accessible Azure storage Uri, either pointed to an Azure blob storage folder, or pointed to a CSV file in Azure blob storage. */
-export interface DetectMultivariateBatchAnomalyDefaultResponse
-  extends HttpResponse {
+export interface DetectMultivariateBatchAnomalyDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponseOutput;
   headers: RawHttpHeaders & DetectMultivariateBatchAnomalyDefaultHeaders;
@@ -211,8 +203,7 @@ export interface DetectMultivariateLastAnomalyDefaultHeaders {
 }
 
 /** Submit multivariate anomaly detection task with the modelId of trained model and inference data, and the inference data should be put into request body in a JSON format. The request will complete synchronously and return the detection immediately in the response body. */
-export interface DetectMultivariateLastAnomalyDefaultResponse
-  extends HttpResponse {
+export interface DetectMultivariateLastAnomalyDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponseOutput;
   headers: RawHttpHeaders & DetectMultivariateLastAnomalyDefaultHeaders;

--- a/sdk/anomalydetector/ai-anomaly-detector-rest/swagger/README.md
+++ b/sdk/anomalydetector/ai-anomaly-detector-rest/swagger/README.md
@@ -20,4 +20,37 @@ rest-level-client: true
 generate-test: true
 # use-extension:
 #   "@autorest/typescript": "6.0.0-rc.1.20220928.1"
+use-extension:
+  "@autorest/modelerfour": "https://tinyurl.com/2dx6b9fg"
+```
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.paths
+    transform: >
+      for (const path of Object.keys($)) {
+         const newPath = path.replace("/{ApiVersion}", "");
+         $[newPath] = $[path];
+         delete $[path];
+      }
+```
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.paths..parameters
+    transform: >
+      if($[0]["$ref"] === "#/parameters/ApiVersion") {
+        $.shift()
+      }
+```
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $["x-ms-parameterized-host"]
+    transform: >
+      $.hostTemplate = "{Endpoint}/anomalydetector/{ApiVersion}";
+      $.parameters.push({"$ref": "#/parameters/ApiVersion"})
 ```


### PR DESCRIPTION
The changes in swagger to work around the parametrized host issue has a negative impact in TS Rest Client as the ApiVersion will now have to be passed on every operation.

Tim was kind enough to put out a fix in M4 https://github.com/Azure/autorest/pull/4657 which I'm using in this change. There is still a gap in the @azure/autorest.typescript plugin to correctly handle it, in the meantime, I have addressed the gap manually.

To make this work I added a few Swagger transforms discussed offline with Laurent

Additionally I'm adding a workaround fix for `isUnexpected` to work correctly with parametrized host.